### PR TITLE
Jitter fix

### DIFF
--- a/client/src/streams/stream.rs
+++ b/client/src/streams/stream.rs
@@ -90,6 +90,7 @@ impl Stream {
             self.jitter_in_ms = 0.0;
             self.jitter_history.clear()
         } else {
+            // RFC 3550
             let clock_rate = rtp.payload_type.clock_rate.unwrap();
             let unit_timestamp = 1.0 / clock_rate as f64;
             let arrival_time_difference_result = packet.timestamp.checked_sub(last_timestamp);
@@ -97,7 +98,7 @@ impl Stream {
                 let timestamp_difference = rtp.timestamp as f64 * unit_timestamp
                     - self.previous_rtp_timestamp.unwrap() * unit_timestamp;
                 let d_in_sec = arrival_time_difference.as_secs_f64() - timestamp_difference;
-                let d_in_ms = d_in_sec * 1000.0;
+                let d_in_ms = d_in_sec.abs() * 1000.0;
 
                 self.jitter_in_ms = self.jitter_in_ms + (d_in_ms - self.jitter_in_ms) / 16.0;
                 self.jitter_history.push(self.jitter_in_ms);


### PR DESCRIPTION
```
interarrival jitter: 32 bits
      An estimate of the statistical variance of the RTP data packet
      interarrival time, measured in timestamp units and expressed as an
      unsigned integer.  The interarrival jitter J is defined to be the
      mean deviation (smoothed absolute value) of the difference D in
      packet spacing at the receiver compared to the sender for a pair
      of packets.  As shown in the equation below, this is equivalent to
      the difference in the "relative transit time" for the two packets;



Schulzrinne, et al.         Standards Track                    [Page 39]

[RFC 3550](https://www.rfc-editor.org/rfc/rfc3550)                          RTP                          July 2003


      the relative transit time is the difference between a packet's RTP
      timestamp and the receiver's clock at the time of arrival,
      measured in the same units.

      If Si is the RTP timestamp from packet i, and Ri is the time of
      arrival in RTP timestamp units for packet i, then for two packets
      i and j, D may be expressed as

         D(i,j) = (Rj - Ri) - (Sj - Si) = (Rj - Sj) - (Ri - Si)

      The interarrival jitter SHOULD be calculated continuously as each
      data packet i is received from source SSRC_n, using this
      difference D for that packet and the previous packet i-1 in order
      of arrival (not necessarily in sequence), according to the formula

         J(i) = J(i-1) + (|D(i-1,i)| - J(i-1))/16

      Whenever a reception report is issued, the current value of J is
      sampled.

      The jitter calculation MUST conform to the formula specified here
      in order to allow profile-independent monitors to make valid
      interpretations of reports coming from different implementations.
      This algorithm is the optimal first-order estimator and the gain
      parameter 1/16 gives a good noise reduction ratio while
      maintaining a reasonable rate of convergence [[22](https://www.rfc-editor.org/rfc/rfc3550#ref-22)].  A sample
      implementation is shown in [Appendix A.8](https://www.rfc-editor.org/rfc/rfc3550#appendix-A.8).  See [Section 6.4.4](https://www.rfc-editor.org/rfc/rfc3550#section-6.4.4) for a
      discussion of the effects of varying packet duration and delay
      before transmission.
```